### PR TITLE
Add release workflow for version tags

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,35 @@
+name: Release build on tag
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run pack
+      - uses: actions/upload-artifact@v3
+        with:
+          name: extension
+          path: web-ext-artifacts/*.zip
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: extension
+          path: web-ext-artifacts
+      - uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          files: web-ext-artifacts/*.zip


### PR DESCRIPTION
## Summary
- build and upload a zip of the browser extension when tagging a release
- create a GitHub release with that zip

## Testing
- `npm run build` *(fails: webpack not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced automated release workflow: builds and publishes a release with packaged extension files whenever a new version tag is pushed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->